### PR TITLE
fix finetuning decryption

### DIFF
--- a/host/examples/classifier.c
+++ b/host/examples/classifier.c
@@ -1279,6 +1279,8 @@ void run_classifier(int argc, char **argv)
         int ngpus;
         int *gpus = read_intlist(gpu_list, &ngpus, gpu_index);
 
+        encrypt = find_int_arg(argc, argv, "-encrypt", 0);
+
         // partition point of DNN
         int pp_start = find_int_arg(argc, argv, "-pp_start", 999);
         if(pp_start == 999){ // when using pp_start_f for forzen first layers outside TEE

--- a/host/examples/detector.c
+++ b/host/examples/detector.c
@@ -1,4 +1,5 @@
 #include "darknet.h"
+#include "parser.h"
 
 static int coco_ids[] = {1,2,3,4,5,6,7,8,9,10,11,13,14,15,16,17,18,19,20,21,22,23,24,25,27,28,31,32,33,34,35,36,37,38,39,40,41,42,43,44,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,67,70,72,73,74,75,76,77,78,79,80,81,82,84,85,86,87,88,89,90};
 
@@ -803,6 +804,24 @@ void run_detector(int argc, char **argv)
     int *gpus = 0;
     int gpu = 0;
     int ngpus = 0;
+
+    encrypt = find_int_arg(argc, argv, "-encrypt", 0);
+
+    // partition point of DNN
+    int pp_start = find_int_arg(argc, argv, "-pp_start", 999);
+    if(pp_start == 999){ // when using pp_start_f for forzen first layers outside TEE
+        pp_start = find_int_arg(argc, argv, "-pp_start_f", 999);
+        frozen_bool = 1;
+    }
+    if(pp_start == 999){ // when using pp_f_only for forzen first layers (all in REE)
+        pp_start = find_int_arg(argc, argv, "-pp_f_only", 999);
+        frozen_bool = 2;
+    }
+
+    partition_point1 = pp_start - 1;
+    int pp_end = find_int_arg(argc, argv, "-pp_end", 999);
+    partition_point2 = pp_end;
+
     if(gpu_list){
         printf("%s\n", gpu_list);
         int len = strlen(gpu_list);

--- a/host/include/darknet.h
+++ b/host/include/darknet.h
@@ -804,6 +804,7 @@ int *read_intlist(char *s, int *n, int d);
 size_t rand_size_t();
 float rand_normal();
 float rand_uniform(float min, float max);
+void run_encrypter(char *cfgfile, char *weightfile, char *filename);
 
 #ifdef __cplusplus
 }

--- a/host/include/main.h
+++ b/host/include/main.h
@@ -87,7 +87,7 @@ void calc_network_loss_CA(int n, int batch);
 
 void net_output_return_CA(int net_outputs, int net_batch);
 
-void transfer_weights_CA(float *vec, int length, int layer_i, char type, int additional);
+void transfer_weights_CA(float *vec, int length, int layer_i, char type, int additional, int encrypt);
 
 void save_weights_CA(float *vec, int length, int layer_i, char type);
 

--- a/host/main.c
+++ b/host/main.c
@@ -469,16 +469,17 @@ void make_cost_layer_CA(int batch, int inputs, COST_TYPE cost_type, float scale,
          res, origin);
 }
 
-void transfer_weights_CA(float *vec, int length, int layer_i, char type, int additional)
+void transfer_weights_CA(float *vec, int length, int layer_i, char type, int additional, int encrypt)
 {
     TEEC_Operation op;
     uint32_t origin;
     TEEC_Result res;
 
-    int passint[3];
+    int passint[4];
     passint[0] = length;
     passint[1] = layer_i;
     passint[2] = additional;
+    passint[3] = encrypt;
 
     memset(&op, 0, sizeof(op));
     op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT, TEEC_MEMREF_TEMP_INPUT, TEEC_VALUE_INPUT, TEEC_NONE);

--- a/host/src/parser.c
+++ b/host/src/parser.c
@@ -46,6 +46,7 @@ int partition_point2 = 0;
 int frozen_bool = 0;
 int sepa_save_bool = 0;
 int global_dp = 0;
+int encrypt = 0;
 
 typedef struct{
     char *type;
@@ -1345,17 +1346,17 @@ void load_connected_weights_comm(layer l, FILE *fp, int i, int transpose)
     fread(l.biases, sizeof(float), l.outputs, fp);
     fread(l.weights, sizeof(float), l.outputs*l.inputs, fp);
 
-    transfer_weights_CA(l.biases, l.outputs, i, 'b', 0);
-    transfer_weights_CA(l.weights, l.outputs*l.inputs, i, 'w', transpose);
+    transfer_weights_CA(l.biases, l.outputs, i, 'b', 0, encrypt);
+    transfer_weights_CA(l.weights, l.outputs*l.inputs, i, 'w', transpose, encrypt);
 
     if (l.batch_normalize && (!l.dontloadscales)){
         fread(l.scales, sizeof(float), l.outputs, fp);
         fread(l.rolling_mean, sizeof(float), l.outputs, fp);
         fread(l.rolling_variance, sizeof(float), l.outputs, fp);
 
-        transfer_weights_CA(l.scales, l.outputs, i, 's', 0);
-        transfer_weights_CA(l.rolling_mean, l.outputs, i, 'm', 0);
-        transfer_weights_CA(l.rolling_variance, l.outputs, i, 'v', 0);
+        transfer_weights_CA(l.scales, l.outputs, i, 's', 0, encrypt);
+        transfer_weights_CA(l.rolling_mean, l.outputs, i, 'm', 0, encrypt);
+        transfer_weights_CA(l.rolling_variance, l.outputs, i, 'v', 0, encrypt);
     }
 }
 
@@ -1377,9 +1378,9 @@ void load_batchnorm_weights_comm(layer l, FILE *fp, int i)
     fread(l.rolling_mean, sizeof(float), l.c, fp);
     fread(l.rolling_variance, sizeof(float), l.c, fp);
 
-    transfer_weights_CA(l.scales, l.c, i, 's', 0);
-    transfer_weights_CA(l.rolling_mean, l.c, i, 'm', 0);
-    transfer_weights_CA(l.rolling_variance, l.c, i, 'v', 0);
+    transfer_weights_CA(l.scales, l.c, i, 's', 0, encrypt);
+    transfer_weights_CA(l.rolling_mean, l.c, i, 'm', 0, encrypt);
+    transfer_weights_CA(l.rolling_variance, l.c, i, 'v', 0, encrypt);
 }
 
 void load_convolutional_weights_binary(layer l, FILE *fp)
@@ -1471,20 +1472,20 @@ void load_convolutional_weights_comm(layer l, FILE *fp, int i)
     int num = l.c/l.groups*l.n*l.size*l.size;
 
     fread(l.biases, sizeof(float), l.n, fp);
-    transfer_weights_CA(l.biases, l.n, i, 'b', 0);
+    transfer_weights_CA(l.biases, l.n, i, 'b', 0, encrypt);
 
     if (l.batch_normalize && (!l.dontloadscales)){
         fread(l.scales, sizeof(float), l.n, fp);
         fread(l.rolling_mean, sizeof(float), l.n, fp);
         fread(l.rolling_variance, sizeof(float), l.n, fp);
 
-        transfer_weights_CA(l.scales, l.n, i, 's', 0);
-        transfer_weights_CA(l.rolling_mean, l.n, i, 'm', 0);
-        transfer_weights_CA(l.rolling_variance, l.n, i, 'v', 0);
+        transfer_weights_CA(l.scales, l.n, i, 's', 0, encrypt);
+        transfer_weights_CA(l.rolling_mean, l.n, i, 'm', 0, encrypt);
+        transfer_weights_CA(l.rolling_variance, l.n, i, 'v', 0, encrypt);
     }
 
     fread(l.weights, sizeof(float), num, fp);
-    transfer_weights_CA(l.weights, num, i, 'w', 0);
+    transfer_weights_CA(l.weights, num, i, 'w', 0, encrypt);
 }
 
 

--- a/host/src/parser.h
+++ b/host/src/parser.h
@@ -9,6 +9,7 @@ extern int frozen_bool;
 extern int sepa_save_bool;
 extern int count_global;
 extern int global_dp;
+extern int encrypt;
 
 void save_network(network net, char *filename);
 void save_weights_double(network net, char *filename);

--- a/ta/darknetp_ta.c
+++ b/ta/darknetp_ta.c
@@ -449,10 +449,11 @@ static TEE_Result transfer_weights_TA_params(uint32_t param_types,
     int length = params1[0];
     int layer_i = params1[1];
     int additional = params1[2];
+    int encrypt = params1[3];
 
     char type = params[2].value.a;
 
-    load_weights_TA(vec, length, layer_i, type, additional);
+    load_weights_TA(vec, length, layer_i, type, additional, encrypt);
 
     return TEE_SUCCESS;
 }

--- a/ta/include/parser_TA.h
+++ b/ta/include/parser_TA.h
@@ -2,7 +2,7 @@
 #define PAR_TA_H
 #include "darknet_TA.h"
 
-void load_weights_TA(float *vec, int length, int layer_i, char type, int transpose);
+void load_weights_TA(float *vec, int length, int layer_i, char type, int transpose, int encrypt);
 
 void save_weights_TA(float *weights_encrypted, int length, int layer_i, char type);
 #endif

--- a/ta/parser_TA.c
+++ b/ta/parser_TA.c
@@ -60,12 +60,12 @@ void transpose_matrix_TA(float *a, int rows, int cols)
 }
 
 
-void load_weights_TA(float *vec, int length, int layer_i, char type, int transpose)
+void load_weights_TA(float *vec, int length, int layer_i, char type, int transpose, int encrypt)
 {
     // decrypt
     float *tempvec = malloc(length*sizeof(float));
     copy_cpu_TA(length, vec, 1, tempvec, 1);
-    aes_cbc_TA("decrypt", tempvec, length);
+    if (encrypt) aes_cbc_TA("decrypt", tempvec, length);
 
     // copy
     layer_TA l = netta.layers[layer_i];
@@ -123,4 +123,5 @@ void save_weights_TA(float *weights_encrypted, int length, int layer_i, char typ
 
     // remove the on-device encryption for FL
     aes_cbc_TA("encrypt", weights_encrypted, length);
+    ;
 }


### PR DESCRIPTION
-encrypt argument를 통해 fine tuning의 대상이 되는 .weight 파일의 encryption 여부를 표기하여, TA 레이어를 만들 때의 decryption 여부를 결정합니다. 본 수정을 통해, REE에서만 training이 진행된 파일로 fine tuning을 할 때 암호화 되지 않은 값을 복호화하지 않습니다.